### PR TITLE
feat : [reservation] boseon

### DIFF
--- a/HyundaiPetReservationService/src/main/webapp/resources/reservation/js/reservation_info_result.js
+++ b/HyundaiPetReservationService/src/main/webapp/resources/reservation/js/reservation_info_result.js
@@ -10,6 +10,7 @@ function reservationInfoReset() {
 	$('.total_price_box').empty();
 	$('.total_price_box').css('display', 'none');
 	sessionStorage.clear();
+	sessionStorage.setItem("reservationRemain", JSON.stringify({}));
 }
 
 function addAllReservation() {


### PR DESCRIPTION
예약 페이지 초기화 후 다시 추가시 정상적으로 동작하지 않는 문제 해결

## 📌Linked Issues
- #64 


## ✏Change Details
-  예약 페이지 초기화 후 다시 추가시 정상적으로 동작하지 않는 문제 해결

## 💬Comment
-

## 📑References
- 

## ✅Check List

- [x] 추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [x] 코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?
